### PR TITLE
Fixed and improved BundleSolver1D

### DIFF
--- a/neurodiffeq/conditions.py
+++ b/neurodiffeq/conditions.py
@@ -228,15 +228,16 @@ class BundleIVP(BaseCondition):
     :param bundle_conditions:
         The initial conditions that will be included in the total bundle,
         in addition to the parameters of the ODE system.
-        The conditions listed in bundle_conditions (e.g bundle_conditions=['t_0', 'u_0', 'u_0_prime']),
-        must be listed in the same order that will be used in ``neurodiffeq.solvers.BundleSolver1D``,
-        when listing theta_min and theta_max.
-        Defaults to []
-    :type bundle_conditions: list[str, ..., str]
+        The values asociated with their respective keys used in bundle_conditions
+        (e.g bundle_conditions={'t_0': 0, 'u_0': 1, 'u_0_prime': 2}),
+        must reflect the index of the tuple used in theta_min and theta_max in ``neurodiffeq.solvers.BundleSolver1D``,
+        (e.g theta_min=(t_0_min, u_0_min, u_0_prime_min)).
+        Defaults to {}
+    :type bundle_conditions: dict{str: int, ..., str: int}
     """
 
     @deprecated_alias(x_0='u_0', x_0_prime='u_0_prime')
-    def __init__(self, t_0=None, u_0=None, u_0_prime=None, bundle_conditions=[]):
+    def __init__(self, t_0=None, u_0=None, u_0_prime=None, bundle_conditions={}):
         super().__init__()
         self.t_0, self.u_0, self.u_0_prime = t_0, u_0, u_0_prime
         self.bundle_conditions = bundle_conditions
@@ -276,13 +277,13 @@ class BundleIVP(BaseCondition):
 
         t_0, u_0, u_0_prime = self.t_0, self.u_0, self.u_0_prime
         if 'u_0' in self.bundle_conditions:
-            u_0 = theta[self.bundle_conditions.index('u_0')]
+            u_0 = theta[self.bundle_conditions['u_0']]
         if 'u_0_prime' in self.bundle_conditions:
-            u_0_prime = theta[self.bundle_conditions.index('u_0_prime')]
+            u_0_prime = theta[self.bundle_conditions['u_0_prime']]
 
         if 't_0' in self.bundle_conditions:
 
-            t_0 = theta[self.bundle_conditions.index('t_0')]
+            t_0 = theta[self.bundle_conditions['t_0']]
 
             if self.u_0_prime is None and 'u_0_prime' not in self.bundle_conditions:
                 return u_0 + (t - t_0) * output_tensor

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -178,24 +178,24 @@ def test_bundleivp(x0, y0, y1, ones, lin, net11, net21, net31, net41):
 
     # Bundle in u_0:
     y_bundle = y0 * lin
-    cond = BundleIVP(t_0=x0, bundle_conditions=['u_0'])
+    cond = BundleIVP(t_0=x0, bundle_conditions={'u_0': 0})
     y = cond.enforce(net21, x, y_bundle)
     assert torch.isclose(y, y0 * lin).all(), "y(x_0) != y_0"
 
-    cond = BundleIVP(t_0=x0, u_0_prime=y1, bundle_conditions=['u_0'])
+    cond = BundleIVP(t_0=x0, u_0_prime=y1, bundle_conditions={'u_0': 0})
     y = cond.enforce(net21, x, y_bundle)
     assert torch.isclose(y, y0 * lin).all(), "y(x_0) != y_0"
     assert all_close(diff(y, x), y1), "y'(x_0) != y'_0"
 
     # Bundle in u_0_prime:
     y_prime_bundle = y1 * lin
-    cond = BundleIVP(t_0=x0, u_0=y0, bundle_conditions=['u_0_prime'])
+    cond = BundleIVP(t_0=x0, u_0=y0, bundle_conditions={'u_0_prime': 0})
     y = cond.enforce(net21, x, y_prime_bundle)
     assert all_close(y, y0), "y(x_0) != y_0"
     assert torch.isclose(diff(y, x), y1 * lin).all(), "y'(x_0) != y'_0"
 
     # Bundle in u_0 and u_0_prime:
-    cond = BundleIVP(t_0=x0, bundle_conditions=['u_0', 'u_0_prime'])
+    cond = BundleIVP(t_0=x0, bundle_conditions={'u_0': 0, 'u_0_prime': 1})
     y = cond.enforce(net31, x, y_bundle, y_prime_bundle)
     assert torch.isclose(y, y0 * lin).all(), "y(x_0) != y_0"
     assert torch.isclose(diff(y, x), y1 * lin).all(), "y'(x_0) != y'_0"
@@ -203,27 +203,27 @@ def test_bundleivp(x0, y0, y1, ones, lin, net11, net21, net31, net41):
     # Bundle in t_0:
     x = x0 * lin
     x_bundle = x0 * lin
-    cond = BundleIVP(u_0=y0, bundle_conditions=['t_0'])
+    cond = BundleIVP(u_0=y0, bundle_conditions={'t_0': 0})
     y = cond.enforce(net21, x, x_bundle)
     assert torch.isclose(y, y0 * ones).all(), "y(x_0) != y_0"
 
-    cond = BundleIVP(u_0=y0, u_0_prime=y1, bundle_conditions=['t_0'])
+    cond = BundleIVP(u_0=y0, u_0_prime=y1, bundle_conditions={'t_0': 0})
     y = cond.enforce(net21, x, x_bundle)
     assert all_close(y, y0), "y(x_0) != y_0"
     assert all_close(diff(y, x), y1), "y'(x_0) != y'_0"
 
     # Bundle in t_0 and u_0:
-    cond = BundleIVP(bundle_conditions=['t_0', 'u_0'])
+    cond = BundleIVP(bundle_conditions={'t_0': 0, 'u_0': 1})
     y = cond.enforce(net31, x, x_bundle, y_bundle)
     assert torch.isclose(y, y0 * lin).all(), "y(x_0) != y_0"
 
-    cond = BundleIVP(u_0_prime=y1, bundle_conditions=['t_0', 'u_0'])
+    cond = BundleIVP(u_0_prime=y1, bundle_conditions={'t_0': 0, 'u_0': 1})
     y = cond.enforce(net31, x, x_bundle, y_bundle)
     assert torch.isclose(y, y0 * lin).all(), "y(x_0) != y_0"
     assert all_close(diff(y, x), y1), "y'(x_0) != y'_0"
 
     # Bundle in t_0, u_0 and u_0_prime:
-    cond = BundleIVP(bundle_conditions=['t_0', 'u_0', 'u_0_prime'])
+    cond = BundleIVP(bundle_conditions={'t_0': 0, 'u_0': 1, 'u_0_prime': 2})
     y = cond.enforce(net41, x, x_bundle, y_bundle, y_prime_bundle)
     assert torch.isclose(y, y0 * lin).all(), "y(x_0) != y_0"
     assert torch.isclose(diff(y, x), y1 * lin).all(), "y'(x_0) != y'_0"


### PR DESCRIPTION
There are two modifications to the use of `BundleSolver1D` and  `BundleIVP` in this pull request. 

The first is a fix of `BundleIVP`, where it didn't work in the case of a bundle that included conditions for different variables in a system of ODEs. To make the fix, now the `bundle_conditions` input takes a `dict`, where in each entry the key represents the condition, and the corresponding value, the index in the tuple used for `theta_min` and `theta_max` in `BundleSolver1D`, where the ranges are indicated for that condition.  
 
The second is an improvement, where now it is not necessary to put the initial conditions as inputs in your `ode_system`, when including them in the bundle.

To illustrate the changes here is an example where a network is trained to be a solution for the damped harmonic oscillator, with different values for the initial time `t_0` (between -1 and 0) initial position `x1_0` (between 0 and 1) and the initial velocity `x2_0` (between 1 and 2): 

First let's create the analytical solution to check how good is the network once it's trained:
```python
import numpy as np

def damp_harm_sol(t, t_0, x_0, x_0_prime, m, b, k):
    x_t = 0

    # Under-damping:
    if b**2 < 4*m*k:

        # Frequency:
        w = np.sqrt(np.abs((b**2)-4*m*k))/(2*m)

        # Exponent factor:
        e = b/(2*m)

        # Parameters:
        c_1 = x_0
        c_2 = (x_0_prime+e*x_0)/w

        # Function:
        x = np.exp(-e*(t-t_0))*(c_1*np.cos(w*(t-t_0))+c_2*np.sin(w*(t-t_0)))
        x_prime = -e*np.exp(-e*(t-t_0))*(c_1*np.cos(w*(t-t_0))+c_2*np.sin(w*(t-t_0))) + w*np.exp(-e*(t-t_0))*(-c_1*np.sin(w*(t-t_0))+c_2*np.cos(w*(t-t_0)))

    return x, x_prime
```
The code to train the network:
```python
import matplotlib.pyplot as plt
from neurodiffeq import diff      # the differentiation operation
from neurodiffeq.conditions import BundleIVP   # the initial condition
from neurodiffeq.solvers import BundleSolver1D  # the solver


# Damped oscilator paramters
m = 1
b = 1
k = 2
x1_0_min = 0
x1_0_max = 1
x2_0_min = 1
x2_0_max = 2
t_0_min = -1
t_0_max = 0
t_f = np.pi

# specify the system of ODEs
def parametric_damp (x1, x2, t):
    A = diff(x1, t) - x2
    B = m*diff(x2, t) + b*x2 + k*x1   

    return A, B

# specify the initial conditions

init_vals_damp = [BundleIVP(bundle_conditions={'t_0': 0, 'u_0': 1}), 
                  BundleIVP(bundle_conditions={'t_0': 0, 'u_0': 2})]  
# Specify in bundle_conditions, the conditions that are to be included in the bundle.
# Where the values in the dict asociated with each condition
# correspond to the index in the tuple in theta_min and theta_max.

# solve the ODE
solution_damp = BundleSolver1D(
    ode_system=parametric_damp, conditions=init_vals_damp, t_min=t_0_min, t_max=t_f,
    theta_min=(t_0_min, x1_0_min, x2_0_min),  # The index of the tuple must match reflect correctly with bundle_conditions, if conditions are part of the bundle
    theta_max=(t_0_max, x1_0_max, x2_0_max)  # The index of the tuple must match reflect correctly with bundle_conditions, if conditions are part of the bundle
    )
solution_damp.fit(max_epochs=5000)
solution = solution_damp.get_solution()
```
Finally some plots:
```python
for t_0 in [-0.9, -0.1]:
  ts = np.linspace(t_0, t_f, 50)
  for x1_0, x2_0 in zip([0.1, 0.1, 0.9, 0.9] , [1.1, 1.9, 1.1, 1.9]):
    x1_net, x2_net = solution(ts, t_0 * np.ones(len(ts)), x1_0 * np.ones(len(ts)), x2_0 * np.ones(len(ts)), to_numpy=True)
    x1_ana, x2_ana = damp_harm_sol(ts, t_0, x1_0, x2_0, m, b, k)

    fig, axs = plt.subplots(1, 1)

    axs.plot(ts, x1_net, label='ANN-based solution of x1', color='C1')
    axs.plot(ts, x1_ana, '.',label='analytical solution of x1', color='C0')
    axs.plot(ts, x2_net, label='ANN-based solution of x2', color='C3')
    axs.plot(ts, x2_ana, '.',label='analytical solution of x2', color='C2')
    axs.set_xlabel('t')
    axs.set_ylabel('x')

    title = 'Damped Harmonic Oscilator \n (' + r'$m={},\;k={},\;b={},\;t_0={},\;x_0={},\;x^\prime_0={}$'.format(m, k, b, t_0, x1_0, x2_0)  + ')'
    axs.set_title(title)
    axs.legend()
    filename = 't={}_x={}_x_prime={}.png'.format(t_0, x1_0, x2_0)
    plt.savefig(filename)

fig, axs = plt.subplots(1, 1)

loss_damp = solution_damp.metrics_history

axs.plot(loss_damp['train_loss'], label='training loss')
axs.plot(loss_damp['valid_loss'], label='validation loss')
axs.set_xlabel('epochs')
axs.set_yscale('log')
axs.set_title('Loss during training')
axs.legend()
plt.savefig('loss.png')
```

![loss](https://user-images.githubusercontent.com/80545608/121254318-7fc63f80-c880-11eb-872b-b3aca8b13949.png)
![t=-0 1_x=0 1_x_prime=1 1](https://user-images.githubusercontent.com/80545608/121254322-80f76c80-c880-11eb-9462-2e640b8b340b.png)
 ![t=-0 1_x=0 1_x_prime=1 9](https://user-images.githubusercontent.com/80545608/121254325-82289980-c880-11eb-8a6a-93318c983b45.png)
![t=-0 1_x=0 9_x_prime=1 1](https://user-images.githubusercontent.com/80545608/121254326-82c13000-c880-11eb-845c-afd333bc1c7c.png)
![t=-0 1_x=0 9_x_prime=1 9](https://user-images.githubusercontent.com/80545608/121254331-8359c680-c880-11eb-947b-5dfc4634450c.png)
![t=-0 9_x=0 1_x_prime=1 1](https://user-images.githubusercontent.com/80545608/121254337-848af380-c880-11eb-8c85-7721c04b28b3.png)
![t=-0 9_x=0 1_x_prime=1 9](https://user-images.githubusercontent.com/80545608/121254342-85238a00-c880-11eb-96ec-27f0a88e5db5.png)
![t=-0 9_x=0 9_x_prime=1 1](https://user-images.githubusercontent.com/80545608/121254347-85bc2080-c880-11eb-93d5-e47b29778a22.png)
![t=-0 9_x=0 9_x_prime=1 9](https://user-images.githubusercontent.com/80545608/121254351-8654b700-c880-11eb-8655-8d04bd1f302f.png)
 
