### PR TITLE
chebyshev_uniform for Generator1D

### DIFF
--- a/neurodiffeq/generators.py
+++ b/neurodiffeq/generators.py
@@ -341,17 +341,13 @@ class Generator3D(BaseGenerator):
             x = _chebyshev_second(xyz_min[0], xyz_max[0], grid[0])
             y = _chebyshev_second(xyz_min[1], xyz_max[1], grid[1])
             z = _chebyshev_second(xyz_min[2], xyz_max[2], grid[2])
-        elif method == 'chebyshev_uniform':
-            x = _chebyshev_uniform(xyz_min[0], xyz_max[0], grid[0])
-            y = _chebyshev_uniform(xyz_min[1], xyz_max[1], grid[1])
-            z = _chebyshev_uniform(xyz_min[2], xyz_max[2], grid[2])
         else:
             raise ValueError(f"Unknown method: {method}")
 
         grid_x, grid_y, grid_z = torch.meshgrid(x, y, z, indexing='ij')
         self.grid_x, self.grid_y, self.grid_z = grid_x.flatten(), grid_y.flatten(), grid_z.flatten()
 
-        if method in ['equally-spaced', 'chebyshev', 'chebyshev1', 'chebyshev2', 'chebyshev_uniform']:
+        if method in ['equally-spaced', 'chebyshev', 'chebyshev1', 'chebyshev2']:
             self.getter = lambda: (self.grid_x, self.grid_y, self.grid_z)
         elif method == 'equally-spaced-noisy':
             self.noise_xmean = torch.zeros(self.size)

--- a/neurodiffeq/generators.py
+++ b/neurodiffeq/generators.py
@@ -5,7 +5,7 @@ import numpy as np
 from typing import List
 
 def _chebyshev_uniform(a, b, n):
-    unif_sample = torch.linspace(0, np.pi, n)
+    unif_sample = torch.rand(n) * np.pi
     nodes = torch.cos(unif_sample)
     nodes = ((a + b) + (b - a) * nodes) / 2
     nodes.requires_grad_(True)
@@ -112,7 +112,7 @@ class Generator1D(BaseGenerator):
         - If set to 'equally-spaced-noisy', a normal noise will be added to the previously mentioned set of points.
         - If set to 'log-spaced', the points will be fixed to a set of log-spaced points that go from t_min to t_max.
         - If set to 'log-spaced-noisy', a normal noise will be added to the previously mentioned set of points,
-        - If set to 'chebyshev_uniform', the points are uniformly sampled between 0 and π, transformed into chebyshev nodes of the first kind, and mapped to (t_min, t_max).
+        - If set to 'chebyshev_uniform', the points are randomly sampled from an uniform distribution between 0 and π, transformed into chebyshev nodes of the first kind, and mapped to (t_min, t_max).
         - If set to 'chebyshev1' or 'chebyshev', the points are chebyshev nodes of the first kind over (t_min, t_max).
         - If set to 'chebyshev2', the points will be chebyshev nodes of the second kind over [t_min, t_max].
 

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -120,6 +120,10 @@ def test_generator1d():
     x = generator.getter()
     assert _check_shape_and_grad(generator, size, x)
 
+    generator = Generator1D(size=size, t_min=0.1, t_max=2.0, method='chebyshev_uniform')
+    x = generator.getter()
+    assert _check_shape_and_grad(generator, size, x)
+
     generator = Generator1D(size=size, t_min=0.1, t_max=2.0, method='chebyshev')
     x = generator.getter()
     assert _check_shape_and_grad(generator, size, x)


### PR DESCRIPTION
As a result of my excellent learning experience in the Harvard ComputeFest 2024: Physics-Informed Neural Networks, I wanted to contribute to neurodiffeq. The perfect opportunity presented by initiative of @shuheng-liu. I open this pull request to create the `chebyshev_uniform` method for `Generator1D`. This should:

- Sample randomly from an uniform distribution between 0 and π
- Generate the Chebyshev nodes of the first kind from this sample
- Map output from (-1, 1) to (tmin, tmax)

I have also updated the documentation and added a test, accordingly.

Thank you!