### PR TITLE
docs: Update advanced.ipynb - removing deprecated alias

### DIFF
--- a/docs/advanced.ipynb
+++ b/docs/advanced.ipynb
@@ -4079,7 +4079,7 @@
     "    conditions=[init_val_ho], \n",
     "    t_min=0.0, \n",
     "    t_max=2*np.pi,\n",
-    "    criterion=L1Loss(),\n",
+    "    loss_fn=L1Loss(),\n",
     ")\n",
     "solver.fit(\n",
     "    max_epochs=1000, \n",


### PR DESCRIPTION
criterion seems to be a deprecated alias for loss_fn