### PR TITLE
APTx Function: Default value of gamma should be 0.5 when trainable=False

### DIFF
--- a/neurodiffeq/networks.py
+++ b/neurodiffeq/networks.py
@@ -190,13 +190,13 @@ class APTx(nn.Module):
     :type trainable: bool
     """
 
-    def __init__(self, alpha=1.0, beta=1.0, gamma=1.0, trainable=False):
+    def __init__(self, alpha=1.0, beta=1.0, gamma=0.5, trainable=False):
         super(APTx, self).__init__()
         alpha = float(alpha)
         beta = float(beta)
         gamma = float(gamma)
         self.trainable = trainable
-        if trainable:
+        if self.trainable:
             self.alpha = nn.Parameter(torch.tensor(alpha))
             self.beta = nn.Parameter(torch.tensor(beta))
             self.gamma = nn.Parameter(torch.tensor(gamma))


### PR DESCRIPTION
In APTx activation function,  the default value of gamma should be 0.5 when trainable=False. One can verify it in the APTx paper here: https://arxiv.org/pdf/2209.06119