### PR TITLE
fix(ci): restore passing test suite under modern numpy/scipy/matplotlib

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install matplotlib==3.7
       - name: Test with pytest
         run: |
           pip install pytest pytest-cov

--- a/neurodiffeq/_version_utils.py
+++ b/neurodiffeq/_version_utils.py
@@ -42,7 +42,7 @@ def deprecated_alias(**aliases):
 def _rename_kwargs(func_name, kwargs, aliases):
     for alias, new in aliases.items():
         if alias in kwargs:
+            warnings.warn(f'The argument `{alias}` is deprecated for {func_name}; use `{new}` instead.', FutureWarning)
             if new in kwargs:
                 raise KeyError(f'{func_name} received both `{alias}` (deprecated) and `{new}` (recommended)')
-            warnings.warn(f'The argument `{alias}` is deprecated for {func_name}; use `{new}` instead.', FutureWarning)
             kwargs[new] = kwargs.pop(alias)

--- a/neurodiffeq/monitors.py
+++ b/neurodiffeq/monitors.py
@@ -339,6 +339,12 @@ class MonitorSpherical(BaseMonitor):
 
     # _update_contourf cannot be defined as a static method since it depends on self.contourf_plot_available
     def _update_contourf(self, var_name, ax, u, colorbar_index):
+        if self.cbs[colorbar_index]:
+            try:
+                self.cbs[colorbar_index].remove()
+            except (AttributeError, KeyError):
+                pass
+            self.cbs[colorbar_index] = None
         ax.clear()
         ax.set_xlabel('$\\phi$')
         ax.set_ylabel('$\\theta$')
@@ -362,8 +368,6 @@ class MonitorSpherical(BaseMonitor):
             # use matshow() to plot a heatmap instead
             cax = ax.matshow(u, cmap='magma', interpolation='nearest')
 
-        if self.cbs[colorbar_index]:
-            self.cbs[colorbar_index].remove()
         self.cbs[colorbar_index] = self.fig.colorbar(cax, ax=ax)
 
     @staticmethod
@@ -731,12 +735,16 @@ class Monitor2D(BaseMonitor):
         ]
 
         for i, (ax, u, con) in enumerate(zip(self.axs[:-2], us, conditions)):
+            if self.cbs[i] is not None:
+                try:
+                    self.cbs[i].remove()
+                except (AttributeError, KeyError):
+                    pass
+                self.cbs[i] = None
             ax.clear()
             u = u.detach().cpu().numpy().flatten()
             if self.solution_style == 'heatmap':
                 cs = self._create_contour(ax, self.xs_plot, self.ys_plot, u, con)
-                if self.cbs[i] is not None:
-                    self.cbs[i].remove()
                 self.cbs[i] = self.fig.colorbar(cs, format='%.0e', ax=ax)
                 ax.set_title(f'u[{i}](x, y)')
             elif self.solution_style == 'curves':

--- a/tests/test_function_basis.py
+++ b/tests/test_function_basis.py
@@ -9,7 +9,14 @@ from neurodiffeq.function_basis import ZonalSphericalHarmonics
 from neurodiffeq.function_basis import ZonalSphericalHarmonicsLaplacian
 from neurodiffeq.neurodiffeq import safe_diff as diff
 from scipy.special import legendre  # legendre polynomials
-from scipy.special import sph_harm  # spherical harmonics
+try:
+    from scipy.special import sph_harm  # spherical harmonics (removed in scipy 1.17)
+except ImportError:
+    from scipy.special import sph_harm_y
+
+    def sph_harm(m, n, theta, phi):
+        # scipy.special.sph_harm_y(n, m, theta, phi) swaps theta/phi roles relative to sph_harm
+        return sph_harm_y(n, m, phi, theta)
 
 
 @pytest.fixture

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -57,7 +57,17 @@ def _check_boundary(xs, xs_min, xs_max):
     return True
 
 
+def _to_flat_numpy(z):
+    if isinstance(z, torch.Tensor):
+        return z.detach().cpu().numpy().reshape(-1)
+    if isinstance(z, np.ndarray):
+        return z.reshape(-1)
+    return list(z)
+
+
 def _check_iterable_equal(x, y, eps=1e-5):
+    x = _to_flat_numpy(x)
+    y = _to_flat_numpy(y)
     for a, b in zip(x, y):
         if abs(float(a) - float(b)) > eps:
             print(f"Different values: {a} != {b}", file=sys.stderr)

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -157,7 +157,7 @@ def test_APTx():
     f = APTx()
     print(list(f.parameters()))
     assert len(list(f.parameters())) == 0
-    assert torch.isclose(f(x),  (1 + torch.nn.Tanh()(x))*x ).all()
+    assert torch.isclose(f(x),  (1 + torch.nn.Tanh()(x))*0.5*x ).all()
 
     alpha = 1.0
     beta = 1.0

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -58,7 +58,7 @@ def test_legacies(solver, generators):
             n_output_units=1,
         ).fit(1)
 
-    class SolverWithLegacyAdditionalLoss(BaseSolver):
+    class SolverWithLegacyAdditionalLoss(GenericSolver):
         def additional_loss(self, funcs, key):
             return 0
     # overriding additional loss is deprecated


### PR DESCRIPTION
## Summary
Restore a passing test suite under modern numpy/scipy/matplotlib. Prior CI failed at collection time because `matplotlib==3.7` is ABI-incompatible with `numpy>=2` and `scipy>=1.17` removed `scipy.special.sph_harm`. Three latent test bugs were also masked by the collection errors.

## Changes
- **`.github/workflows/CI.yml`** — drop the `matplotlib==3.7` install step; the version pulled in by `requirements.txt` works.
- **`neurodiffeq/_version_utils.py`** — emit the deprecation `FutureWarning` *before* raising `KeyError` in `_rename_kwargs`, so both are observable when a deprecated and a new kwarg are passed together.
- **`neurodiffeq/monitors.py`** — remove stale colorbars *before* `ax.clear()` (and wrap the remove in try/except) so `matplotlib>=3.10`'s `Colorbar.remove()` doesn't crash on a cleared mappable.
- **`tests/test_function_basis.py`** — fall back to `scipy.special.sph_harm_y` (with the arg-order swap) when `sph_harm` is unavailable.
- **`tests/test_generators.py`** — flatten inputs in `_check_iterable_equal` so `float(numpy_array)` works under numpy 2.x (only 0-d arrays are scalar-convertible there).
- **`tests/test_networks.py::test_APTx`** — update expected value for the new default `gamma=0.5` introduced in #222.
- **`tests/test_solvers.py::test_legacies`** — derive `SolverWithLegacyAdditionalLoss` from concrete `GenericSolver` so instantiation reaches the deprecated `additional_loss` path (`BaseSolver.get_solution` is abstract).

## Test plan
- [x] `pytest --cov=neurodiffeq/` on Python 3.10 — **294 passed**
- [x] `pytest --cov=neurodiffeq/` on Python 3.11 — **294 passed**
- [ ] CI green on the PR

https://claude.ai/code/session_01PCv9YHjQAeePohXSToKVk9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCv9YHjQAeePohXSToKVk9)_